### PR TITLE
Add main attribute to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
   "title": "jQuery-QuickSearch",
   "description": "A jQuery plugin for searching through tables, lists, etc quickly",
   "version": "2.0.4",
+  "main": "dist/jquery.quicksearch.js",
   "homepage": "",
   "author": [
     {


### PR DESCRIPTION
Adding a "main" url attribute should help with bower installations.
