### PR TITLE
fix: noResults element not shown on page-load #23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .project
 .settings
 node_modules
+bower_components

--- a/examples/index.html
+++ b/examples/index.html
@@ -95,6 +95,10 @@
 					'table#table_noResultFunction tbody tr',
 					{'onNoResultFound': exampleFunction}
 				);				
+                
+                $("#noResultSearch").quicksearch("#noResultList li", {
+                  noResults: "#noResultMessage"
+                });
 			});
 		</script>
 	</head>
@@ -861,6 +865,24 @@ $('input#id_noResultFunction').quicksearch(
 	'table#table_noResultFunction tbody tr',
 	{'onNoResultFound': exampleFunction}
 );		
+</pre></code>
+
+<h3>Show element when no results are found</h3>
+
+<input type="text" id="noResultSearch" name="search">
+  <ul id="noResultList">
+    <li>Apple</li>
+    <li>Banana</li>
+    <li>Lemon</li>
+  </ul>
+  <div id="noResultMessage" class="no-results-container">
+      No results have been found.
+  </div>
+  <p>This example uses the following code:</p>
+  <code><pre>
+$("#noResultSearch").quicksearch("#noResultList li", {
+  noResults: "#noResultMessage"
+});
 </pre></code>
 
 <p><a href="super_table.html">Super table example</a></p>

--- a/examples/index.html
+++ b/examples/index.html
@@ -95,10 +95,10 @@
 					'table#table_noResultFunction tbody tr',
 					{'onNoResultFound': exampleFunction}
 				);				
-                
-                $("#noResultSearch").quicksearch("#noResultList li", {
-                  noResults: "#noResultMessage"
-                });
+				
+				$("#noResultSearch").quicksearch("#noResultList li", {
+					noResults: "#noResultMessage"
+				});
 			});
 		</script>
 	</head>

--- a/examples/style.css
+++ b/examples/style.css
@@ -35,3 +35,10 @@ form input { font-size: 16px;}
 .github a { background: #fff172; padding: 3px 10px;}
 
 #id_search {width: 300px;}
+
+.no-results-container {
+    background: #f34105;
+    color: #fff;
+    font-weight: bold;
+    padding: 1em;
+}

--- a/src/jquery.quicksearch.js
+++ b/src/jquery.quicksearch.js
@@ -315,7 +315,6 @@
 		};
 		
 		this.cache();
-		this.results(true);
 		this.stripe();
 		this.loader(false);
 		


### PR DESCRIPTION
Fixed by removing the call to this.results in the function’s main body.
This call seems to be unnecessary, as I could not find any side-effects that this fix might cause.
Resubmitted without the built files.